### PR TITLE
DB URL patch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+*.sh eol=lf
+
+# Git LFS
 *.pdf filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -12,7 +12,7 @@ ADMINS =  decouple.config('ADMINS', cast=list_of_tuples)
 
 MANAGERS = ADMINS
 
-if os.getenv('GAE_APPLICATION', None):
+if os.getenv('GAE_APPLICATION', None) and not DATABASES:
     # Running on production App Engine, so connect to Google Cloud SQL using
     # the unix socket at /cloudsql/<your-cloudsql-connection string>
     DATABASES = {

--- a/scripts/deploy_to_app_engine.sh
+++ b/scripts/deploy_to_app_engine.sh
@@ -47,6 +47,7 @@ env_variables=(
 
     # Database
     "DATABASE_INSTANCE_CONNECTION_NAME"
+    "DATABASE_URL"
     "DB_ENGINE"
     "DB_NAME"
     "DB_USER"
@@ -64,7 +65,7 @@ env_variables=(
 for var in "${env_variables[@]}"; do
     # get the environment variable string(key) and actual value
     case "$var" in
-        *"CREDENTIALS"* | *"PASSWORD"* | *"SECRET"*)
+        *"CREDENTIALS"* | *"PASSWORD"* | *"SECRET"* | *"URL"*)
             echo "  $var: '${!var}'" >> app.yaml
             ;;
 


### PR DESCRIPTION
Don't override `DATABASE`  setting in Google App Engine when `DATABASE_URL` is set